### PR TITLE
Expose stats to template

### DIFF
--- a/examples/roc-package-web-app-react/complex/src/template-values.js
+++ b/examples/roc-package-web-app-react/complex/src/template-values.js
@@ -1,4 +1,4 @@
-export default function getTemplateValues(/* { koaState, settings, reduxState } */) {
+export default function getTemplateValues(/*{ koaState, settings, reduxState, stats }*/) {
     return {
         bodyClass: 'main'
     };

--- a/packages/roc-package-web-app-dev/package.json
+++ b/packages/roc-package-web-app-dev/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "roc": "^1.0.0-rc.23",
-    "roc-package-webpack-dev": "^1.0.0",
-    "roc-package-webpack-node-dev": "^1.0.0",
+    "roc-package-webpack-dev": "^1.1.0",
+    "roc-package-webpack-node-dev": "^1.0.1",
     "roc-package-webpack-web-dev": "^1.0.0",
     "roc-plugin-browsersync": "^1.0.0",
     "roc-plugin-style-css": "^1.0.0",

--- a/packages/roc-package-web-app-react-dev/package.json
+++ b/packages/roc-package-web-app-react-dev/package.json
@@ -30,7 +30,7 @@
     "redux-devtools-log-monitor": "~1.3.0",
     "redux-logger": "~2.6.1",
     "roc": "^1.0.0-rc.23",
-    "roc-package-web-app-dev": "^1.0.0",
+    "roc-package-web-app-dev": "^1.0.1",
     "roc-plugin-react-dev": "^1.0.0",
     "yellowbox-react": "~0.10.0"
   },

--- a/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -92,9 +92,8 @@ export function initRenderPage(distMode, devMode, Header) {
         stats,
     } = {}) => {
         const { dev, build, ...rest } = rocConfig; // eslint-disable-line
-        const buildName = rocConfig.build.name;
-        const bundleName = stats.script[buildName][0];
-        const styleName = (stats.css[buildName] || [])[0];
+        const bundleName = stats.script[build.name][0];
+        const styleName = (stats.css[build.name] || [])[0];
 
         const rocConfigClient = distMode ? rest : { ...rest, dev };
 

--- a/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -73,14 +73,12 @@ function setupTemplate(devMode) {
     };
 }
 
-export function initRenderPage({ script, css }, distMode, devMode, Header) {
+export function initRenderPage(distMode, devMode, Header) {
     const {
         nunjucksEnv,
         nunjucksContext,
         mainTemplate,
     } = setupTemplate(devMode);
-    const bundleName = script[0];
-    const styleName = css[0];
 
     return ({
         content = '',
@@ -91,8 +89,12 @@ export function initRenderPage({ script, css }, distMode, devMode, Header) {
         reduxState = {},
         request,
         status,
+        stats,
     } = {}) => {
         const { dev, build, ...rest } = rocConfig; // eslint-disable-line
+        const buildName = rocConfig.build.name;
+        const bundleName = stats.script[buildName][0];
+        const styleName = (stats.css[buildName] || [])[0];
 
         const rocConfigClient = distMode ? rest : { ...rest, dev };
 
@@ -116,6 +118,7 @@ export function initRenderPage({ script, css }, distMode, devMode, Header) {
             request,
             serializedAppConfig: serialize(appConfig),
             serializedRocConfig: serialize(rocConfigClient),
+            stats,
             status,
             styleName,
         });
@@ -134,6 +137,7 @@ export function reactRender({
     hasTemplateValues,
     templateValues,
     reduxSagas,
+    stats,
 }) {
     return new Promise((resolve) => {
         let currentLocation;
@@ -225,6 +229,7 @@ export function reactRender({
                         koaState,
                         settings: rocConfig,
                         reduxState,
+                        stats,
                     });
 
                     if (hasTemplateValues) {
@@ -235,6 +240,7 @@ export function reactRender({
                                 koaState,
                                 settings: rocConfig,
                                 reduxState,
+                                stats,
                             }),
                         );
                     }
@@ -248,19 +254,20 @@ export function reactRender({
                             reduxState,
                             request,
                             status,
+                            stats,
                         }),
                         status,
                     });
                 })
-                .catch((err) => {
-                    if (err) {
-                        log('General error', pretty.render(err));
-                    }
-                    return resolve({
-                        status: 500,
-                        body: renderPage({ error: err, request, status: 500 }),
+                    .catch((err) => {
+                        if (err) {
+                            log('General error', pretty.render(err));
+                        }
+                        return resolve({
+                            status: 500,
+                            body: renderPage({ error: err, request, status: 500, stats }),
+                        });
                     });
-                });
             });
     });
 }

--- a/packages/roc-package-web-app-react/src/app/server/reactRouter.js
+++ b/packages/roc-package-web-app-react/src/app/server/reactRouter.js
@@ -73,6 +73,7 @@ export default function reactRouter({
                     hasTemplateValues,
                     templateValues,
                     reduxSagas,
+                    stats,
                 });
 
                 if (redirect) {

--- a/packages/roc-package-webpack-dev/src/actions/dev.js
+++ b/packages/roc-package-webpack-dev/src/actions/dev.js
@@ -2,7 +2,7 @@ import { stat, writeFileSync } from 'fs';
 import { join } from 'path';
 
 import { sync } from 'mkdirp';
-import { appendSettings, initLog } from 'roc';
+import { appendSettings, getSettings, initLog } from 'roc';
 import { cleanPromise } from 'roc-abstract-package-base-dev';
 import webpack from 'webpack';
 
@@ -17,10 +17,14 @@ const writeStatsFile = (buildPath, scriptPath) =>
             if (err) {
                 sync(buildPath);
             }
-
+            const bundleName = getSettings('build').name;
             writeFileSync(join(buildPath, 'webpack-stats.json'), JSON.stringify({
-                script: [`${scriptPath}`],
-                css: '',
+                script: {
+                    [bundleName]: [`${scriptPath}`],
+                },
+                css: {
+                    [bundleName]: undefined,
+                },
             }));
 
             return resolve();

--- a/packages/roc-package-webpack-dev/src/webpack/utils/stats.js
+++ b/packages/roc-package-webpack-dev/src/webpack/utils/stats.js
@@ -1,8 +1,6 @@
 import { writeFileSync } from 'fs';
 import { extname, join } from 'path';
 
-import { getSettings } from 'roc';
-
 /**
  * A parser for stats that find all JS and CSS files
  *
@@ -51,9 +49,7 @@ export function writeStats(stats) {
     const analysisFilepath = join(this.options.output.path, 'webpack-analysis.json');
 
     const json = stats.toJson();
-    const name = getSettings('build').name;
-
-    const content = parseStats(json, publicPath, name);
+    const content = parseStats(json, publicPath);
 
     writeFileSync(statsFilepath, JSON.stringify(content));
     writeFileSync(analysisFilepath, JSON.stringify(json));

--- a/packages/roc-package-webpack-dev/src/webpack/utils/stats.js
+++ b/packages/roc-package-webpack-dev/src/webpack/utils/stats.js
@@ -11,23 +11,24 @@ import { getSettings } from 'roc';
  * @returns {object} A object with keys for 'script' and 'css'
  * @private
  */
-export function parseStats(stats, publicPath = '', name = 'app') {
+export function parseStats(stats, publicPath = '') {
     // get chunks by name and extensions
-    const getChunks = (n, ext = 'js') => {
-        let chunk = stats.assetsByChunkName[n];
+    const getChunks = (ext = 'js') => {
+        const chunk = stats.assetsByChunkName;
+        return Object.keys(chunk).reduce((chunksForExtension, chunkName) => {
+            // a chunk could be a string or an array, so make sure it is an array
+            chunksForExtension[chunkName] = [].concat(chunk[chunkName]);
 
-        // a chunk could be a string or an array, so make sure it is an array
-        if (!(Array.isArray(chunk))) {
-            chunk = [chunk];
-        }
+            chunksForExtension[chunkName] = chunksForExtension[chunkName]
+                .filter((c) => extname(c) === `.${ext}`)
+                .map((c) => publicPath + c);
 
-        return chunk
-            .filter((chunkName) => extname(chunkName) === `.${ext}`)
-            .map((chunkName) => publicPath + chunkName);
+            return chunksForExtension;
+        }, {});
     };
 
-    const script = getChunks(name, 'js');
-    const css = getChunks(name, 'css');
+    const script = getChunks('js');
+    const css = getChunks('css');
 
     return {
         script,

--- a/packages/roc-package-webpack-node-dev/package.json
+++ b/packages/roc-package-webpack-node-dev/package.json
@@ -26,7 +26,7 @@
     "debug": "~2.2.0",
     "node-watch": "~0.3.4",
     "roc": "^1.0.0-rc.23",
-    "roc-package-webpack-dev": "^1.0.0",
+    "roc-package-webpack-dev": "^1.1.0",
     "roc-plugin-start": "^1.0.0"
   },
   "roc": {

--- a/packages/roc-package-webpack-node-dev/src/watcher/server.js
+++ b/packages/roc-package-webpack-node-dev/src/watcher/server.js
@@ -128,11 +128,12 @@ export default function server(compiler) {
                 statsJson.warnings.map(wrn => log.small.warn(wrn));
             }
 
-            let bundleName = `${getSettings('build').name}.js`;
+            const buildName = getSettings('build').name;
+            let bundleName = `${buildName}.js`;
 
             if (statsJson.assets && statsJson.assets.length > 0) {
                 const stats = parseStats(statsJson);
-                bundleName = stats.script[0];
+                bundleName = stats.script[buildName][0];
             }
 
             const artifact = path.join(compiler.outputPath, '/', bundleName);

--- a/plugins/roc-plugin-test-mocha-webpack/package.json
+++ b/plugins/roc-plugin-test-mocha-webpack/package.json
@@ -31,7 +31,7 @@
     "rimraf": "~2.5.2",
     "roc": "^1.0.0-rc.23",
     "roc-abstract-plugin-test": "^1.0.0",
-    "roc-package-webpack-dev": "^1.0.0",
+    "roc-package-webpack-dev": "^1.1.0",
     "roc-plugin-start": "^1.0.0",
     "source-map-support": "0.4.0"
   },

--- a/plugins/roc-plugin-test-mocha-webpack/src/nyc/index.js
+++ b/plugins/roc-plugin-test-mocha-webpack/src/nyc/index.js
@@ -43,10 +43,11 @@ function getArtifact(compiler, err, stats) {
         return undefined;
     }
 
-    let bundleName = `${getSettings('build').name}.js`;
+    const buildName = getSettings('build').name;
+    let bundleName = `${buildName}.js`;
 
     if (statsJson.assets && statsJson.assets.length > 0) {
-        bundleName = parseStats(statsJson).script[0];
+        bundleName = parseStats(statsJson).script[buildName][0];
     }
 
     return path.join(compiler.outputPath, '/', bundleName);


### PR DESCRIPTION
This PR


- feat(roc-package-web-app-react): Expose new stats object to template values 
  - Makes it possible to get all the chunks (css, scripts) in the template.

- fix(roc-package-webpack-node-dev): Use new stats object format
  - This also solves a problem where we wouldn't find the bundle based on the build.name
being different than the default "app".


- feat(roc-package-webpack-dev): Export stats as object with all chunks