### PR TITLE
Support React 16 (as well as 15)

### DIFF
--- a/examples/roc-package-web-app-react/complex/package.json
+++ b/examples/roc-package-web-app-react/complex/package.json
@@ -7,7 +7,10 @@
   "license": "MIT",
   "dependencies": {
     "koa-session": "3.4.0",
-    "react-toggle": "~2.1.1",
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-toggle": "^4.0.2",
     "redux-api-middleware": "~1.0.2",
     "redux-fetcher": "~2.0.0",
     "roc-package-web-app-react": "^1.0.0"

--- a/examples/roc-package-web-app-react/complex/src/components/app/index.js
+++ b/examples/roc-package-web-app-react/complex/src/components/app/index.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Link from 'react-router/lib/Link';
 import IndexLink from 'react-router/lib/IndexLink';
 
 export default class App extends Component {
     static propTypes = {
-        children: React.PropTypes.object
+        children: PropTypes.object
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/clicker/index.js
+++ b/examples/roc-package-web-app-react/complex/src/components/clicker/index.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import styles from './style.css';
 import sharedStyles from './../shared.css';
 
 export default class Clicker extends Component {
     static propTypes = {
-        clicker: React.PropTypes.number.isRequired,
-        click: React.PropTypes.func.isRequired
+        clicker: PropTypes.number.isRequired,
+        click: PropTypes.func.isRequired
     };
 
     render() {
         return (
             <div className={ styles.clicker }>
-                <h1>Clicker</h1>
+                <h1>Clicker!</h1>
                 <div>
                     { this.props.clicker }
                     <button className={ sharedStyles.button } onClick={ this.props.click }>Click me!</button>

--- a/examples/roc-package-web-app-react/complex/src/components/errors/index.js
+++ b/examples/roc-package-web-app-react/complex/src/components/errors/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import ErrorItem from './item';
 
@@ -8,8 +9,8 @@ export default class Errors extends Component {
     };
 
     static propTypes = {
-        errors: React.PropTypes.array,
-        resetErrors: React.PropTypes.func
+        errors: PropTypes.array,
+        resetErrors: PropTypes.func
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/errors/item.js
+++ b/examples/roc-package-web-app-react/complex/src/components/errors/item.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import styles from './style.css';
 
@@ -9,8 +10,8 @@ export default class ErrorItem extends Component {
     };
 
     static propTypes = {
-        key: React.PropTypes.number.isRequired,
-        error: React.PropTypes.string.isRequired
+        key: PropTypes.number.isRequired,
+        error: PropTypes.string.isRequired
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/main/index.js
+++ b/examples/roc-package-web-app-react/complex/src/components/main/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { provideHooks } from 'redial';
@@ -48,16 +49,16 @@ function mapDispatchToProps(dispatch) {
 export default class Main extends React.Component {
     static propTypes = {
         // bound actions
-        click: React.PropTypes.func.isRequired,
-        resetErrors: React.PropTypes.func.isRequired,
-        createFetchAction: React.PropTypes.func.isRequired,
-        reposForceFetch: React.PropTypes.func.isRequired,
-        updateUser: React.PropTypes.func.isRequired,
-        repoUser: React.PropTypes.string,
+        click: PropTypes.func.isRequired,
+        resetErrors: PropTypes.func.isRequired,
+        createFetchAction: PropTypes.func.isRequired,
+        reposForceFetch: PropTypes.func.isRequired,
+        updateUser: PropTypes.func.isRequired,
+        repoUser: PropTypes.string,
         // connected values from store
-        clicker: React.PropTypes.number,
-        repositories: React.PropTypes.object,
-        errors: React.PropTypes.array
+        clicker: PropTypes.number,
+        repositories: PropTypes.object,
+        errors: PropTypes.array
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/repo/button.js
+++ b/examples/roc-package-web-app-react/complex/src/components/repo/button.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import sharedStyles from '../shared.css';
 
 export default class RepoUpdateButton extends Component {
     static propTypes = {
-        text: React.PropTypes.string,
-        onClick: React.PropTypes.func
+        text: PropTypes.string,
+        onClick: PropTypes.func
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/repo/data.js
+++ b/examples/roc-package-web-app-react/complex/src/components/repo/data.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import styles from './style.css';
 
 export default class RepoData extends Component {
     static propTypes = {
-        city: React.PropTypes.object,
-        list: React.PropTypes.array
+        city: PropTypes.object,
+        list: PropTypes.array
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/repo/error.js
+++ b/examples/roc-package-web-app-react/complex/src/components/repo/error.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class RepoError extends Component {
     static propTypes = {
-        error: React.PropTypes.string
+        error: PropTypes.string
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/repo/index.js
+++ b/examples/roc-package-web-app-react/complex/src/components/repo/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import styles from './style.css';
 
@@ -9,13 +10,13 @@ import RepoUpdateButton from './button';
 
 export default class Repo extends Component {
     static propTypes = {
-        payload: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.array]),
-        loading: React.PropTypes.bool,
-        endpoint: React.PropTypes.string,
-        reposForceFetch: React.PropTypes.func,
-        updateUser: React.PropTypes.func,
-        repoUser: React.PropTypes.string,
-        error: React.PropTypes.bool
+        payload: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+        loading: PropTypes.bool,
+        endpoint: PropTypes.string,
+        reposForceFetch: PropTypes.func,
+        updateUser: PropTypes.func,
+        repoUser: PropTypes.string,
+        error: PropTypes.bool
     };
 
     render() {

--- a/examples/roc-package-web-app-react/complex/src/components/repo/loader.js
+++ b/examples/roc-package-web-app-react/complex/src/components/repo/loader.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Repo extends Component {
     static propTypes = {
-        endpoint: React.PropTypes.string
+        endpoint: PropTypes.string
     };
 
     render() {

--- a/packages/roc-package-web-app-react/app/client/render-to-dom.js
+++ b/packages/roc-package-web-app-react/app/client/render-to-dom.js
@@ -1,8 +1,9 @@
-/* eslint-disable global-require */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'react-router/lib/Router';
 import match from 'react-router/lib/match';
+
+import { rocConfig } from '../shared/universal-config';
 
 function renderSync({ renderProps, createComponent, routerRenderFn }, node) {
     const finalComponent = createComponent(
@@ -12,7 +13,12 @@ function renderSync({ renderProps, createComponent, routerRenderFn }, node) {
         />
     );
 
-    ReactDOM.render(finalComponent, node);
+    // If we have enabled SSR and we are on React 16
+    if (rocConfig.runtime.ssr && ReactDOM.hydrate) {
+        ReactDOM.hydrate(finalComponent, node);
+    } else {
+        ReactDOM.render(finalComponent, node);
+    }
 }
 
 export default function renderAsync({ history, routes, ...rest }, node) {

--- a/packages/roc-package-web-app-react/package.json
+++ b/packages/roc-package-web-app-react/package.json
@@ -32,6 +32,7 @@
     "intl-locales-supported": "^1.0.0",
     "nunjucks": "~2.4.2",
     "pretty-error": "^2.1.0",
+    "prop-types": "^15.6.0",
     "react-helmet": "~5.0.3",
     "react-redux": "^5.0.4",
     "react-router": "^3.0.5",
@@ -45,7 +46,7 @@
     "redux-thunk": "^2.2.0",
     "roc": "^1.0.0-rc.23",
     "roc-package-web-app": "^1.0.0",
-    "roc-plugin-react": "^1.0.0",
+    "roc-plugin-react": "^2.0.0",
     "serialize-javascript": "~1.2.0"
   },
   "roc": {

--- a/plugins/roc-plugin-react/package.json
+++ b/plugins/roc-plugin-react/package.json
@@ -18,12 +18,7 @@
     }
   ],
   "license": "MIT",
-  "dependencies": {
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "roc": "^1.0.0-rc.23"
-  },
+  "dependencies": {},
   "roc": {
     "packages": [
       "./lib/index.js"

--- a/plugins/roc-plugin-react/src/roc/index.js
+++ b/plugins/roc-plugin-react/src/roc/index.js
@@ -1,13 +1,29 @@
-import { generateDependencies } from 'roc';
-
-const packageJSON = require('../../package.json');
+import path from 'path';
 
 export default {
     dependencies: {
-        exports: generateDependencies(packageJSON, [
-            'prop-types',
-            'react',
-            'react-dom',
-        ]),
+        exports: {
+            // TODO
+            // This is currently here to manage a "problem" when working with locally linked packages
+            // This will give a warning the the projects that use this plugin
+            // We want to change core to support this in a better way in the future.
+            // One way could be to no give warnings if the version is undefined/false
+            // Another could be to let Roc be smart about this and automatically solve the
+            // peerDependecy problems that exists in Node and that we here go around
+            // Another useful thing is to get the context.directory here directly instead of needing
+            // to use process.cwd()
+            react: {
+                version: 'IGNORE THE WARNING THAT YOU SEE',
+                resolve: ({ request }) => require.resolve(path.join(process.cwd(), 'node_modules', request)),
+            },
+            'react-dom': {
+                version: 'IGNORE THE WARNING THAT YOU SEE',
+                resolve: ({ request }) => require.resolve(path.join(process.cwd(), 'node_modules', request)),
+            },
+        },
+        requires: {
+            react: '^15.5.4 || ^16.0.0',
+            'react-dom': '^15.5.4 || ^16.0.0',
+        },
     },
 };


### PR DESCRIPTION
This PR changes how we manage [React](https://reactjs.org) in Roc. We will treat this change as a breaking change since it requires interaction by the application developer.

Instead of providing it through  `exports` we know require it using  _`requires`_, similar to how `peerDependencies` work. This gives applications more freedom since they now can select the version of React that their application works with and also is supported by their Roc extensions.

This means that applications now are responsible for adding dependencies on `react`, `react-dom` and `prop-types` _(if not they already had it)_.

```bash
npm install --save react react-dom prop-types
```
Is all that is needed in the project after upgrading and will make the project use the latest version of each of those packages, meaning React 16.

__Known problems__  
- There is a problem with Redux Dev Tools that makes React show a warning, tracked in https://github.com/alexkuz/react-json-tree/issues/94.
- A warning from Roc will be seen, see below, this can be ignored and will be removed before the stable release. Currently used to get npm link to work during local development.
<img width="734" alt="screen shot 2017-10-26 at 11 49 44" src="https://user-images.githubusercontent.com/2854610/32049137-d0f20a3c-ba43-11e7-9a9a-bc00268cdfe9.png">
