### PR TITLE
Reuse status from caught errors

### DIFF
--- a/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
+++ b/packages/roc-package-web-app-react/src/app/server/reactRenderer.js
@@ -286,12 +286,13 @@ export function reactRender({
                     if (err) {
                         log('General error', pretty.render(err));
                     }
+                    const { status = 500 } = err || {};
                     return resolve({
-                        status: 500,
+                        status,
                         body: renderPage({
                             error: err,
                             request,
-                            status: 500,
+                            status,
                             stats,
                             reduxState: store ? store.getState() : {},
                         }),


### PR DESCRIPTION
Background:
We have koa middlewares checking authentication and setting status 401/403 like 

```js
function* middleWare(ctx, next) {
  if (!isAuthorized(ctx)) {
     ctx.throw(401, 'Missing credentials');
  }
  yield next;
}
```

The status code is currently lost and all responses get http 500 status.