### PR TITLE
fix(roc-package-web-app): Don't always compress the response

### DIFF
--- a/packages/roc-package-web-app/package.json
+++ b/packages/roc-package-web-app/package.json
@@ -29,7 +29,7 @@
     "koa": "~1.1.1",
     "koa-accesslog": "~0.0.2",
     "koa-add-trailing-slashes": "~1.1.0",
-    "koa-compressor": "~1.0.3",
+    "koa-compress": "~1.0.9",
     "koa-conditional-get": "~1.0.3",
     "koa-errors": "~1.0.1",
     "koa-etag": "~2.0.0",

--- a/packages/roc-package-web-app/src/app/middlewares.js
+++ b/packages/roc-package-web-app/src/app/middlewares.js
@@ -1,7 +1,7 @@
 import koaErrors from 'koa-errors';
 import helmet from 'koa-helmet';
 import koaEtag from 'koa-etag';
-import koaCompressor from 'koa-compressor';
+import koaCompress from 'koa-compress';
 import koaFavicon from 'koa-favicon';
 import koaAccesslog from 'koa-accesslog';
 import koaLogger from 'koa-logger';
@@ -26,7 +26,7 @@ export default function middlewares(config, { dev, dist }) {
 
     // We only enable gzip in dist
     if (dist) {
-        middlewaresList.push(koaCompressor());
+        middlewaresList.push(koaCompress());
     }
 
     const favicon = config.favicon;


### PR DESCRIPTION
Use `koa-compress` over `koa-compressor` to not always compress the response.