### PR TITLE
fix(roc-package-web-app-react-dev): Up redux-devtools-log-monitotor

### DIFF
--- a/packages/roc-package-web-app-react-dev/package.json
+++ b/packages/roc-package-web-app-react-dev/package.json
@@ -27,7 +27,7 @@
     "react-a11y": "~0.3.3",
     "redux-devtools": "~3.4.0",
     "redux-devtools-dock-monitor": "~1.1.2",
-    "redux-devtools-log-monitor": "~1.3.0",
+    "redux-devtools-log-monitor": "~1.4.0",
     "redux-logger": "~2.6.1",
     "roc": "^1.0.0-rc.23",
     "roc-package-web-app-dev": "^1.0.1-alpha.1",


### PR DESCRIPTION
When moving to _React 16_ we started experiencing a lot of validation errors in our app, complaining about `onClick` not being allowed to receive boolean. This has been adressed in [this issue](https://github.com/gaearon/redux-devtools-log-monitor/issues/69) and is part of version 1.4 of the library.

So, this pulls simply upgrades the lib to version 1.4 and the console is a bliss again :)